### PR TITLE
fix exception in browsers

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -10,9 +10,9 @@ const IndexPage = () => {
 
 	return (
 		<>
-			<h1>
-				<h3>Setting up Apollo GraphQL in Next.js with Server Side Rendering</h3>
-			</h1>
+			<ul>
+				<li>Setting up Apollo GraphQL in Next.js with Server Side Rendering</li>
+			</ul>
 			<div>
 				{data.characters.results.map((data) => (
 					<ul key={data.id}>


### PR DESCRIPTION
Having h3 inside h1 is not allowed by HTML spec, so browsers throw an exception due to that.
Fix that problem by replacing ul > li that will be semantically more correct here, for the list.